### PR TITLE
Migrate asdf

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,7 +14,7 @@ jobs:
       run: rm ~/.gitconfig
 
     - name: Install Homebrew
-      run: /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+      run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
     - name: Install Ansible
       run: brew install ansible

--- a/ansible-playbook/roles/config/files/asdfrc
+++ b/ansible-playbook/roles/config/files/asdfrc
@@ -1,0 +1,1 @@
+legacy_version_file = yes

--- a/ansible-playbook/roles/config/files/zsh/.zshrc
+++ b/ansible-playbook/roles/config/files/zsh/.zshrc
@@ -33,7 +33,8 @@ source $ZDOTDIR/.zshrc.anyframe
 
 include /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc
 
-eval "$(anyenv init - zsh)"
 eval "$(direnv hook zsh)"
 
 eval "$(starship init zsh)"
+
+. $(brew --prefix asdf)/libexec/asdf.sh

--- a/ansible-playbook/roles/dotfiles/files/.zshenv
+++ b/ansible-playbook/roles/dotfiles/files/.zshenv
@@ -3,7 +3,12 @@ include () {
 }
 
 export XDG_CONFIG_HOME=${XDG_CONFIG_HOME:=${HOME}/.config}
+export XDG_DATA_HOME=${XDG_DATA_HOME:=$HOME/.local/share}
+
 export ZDOTDIR=${ZDOTDIR:=${XDG_CONFIG_HOME}/zsh}
+
+export ASDF_DATA_DIR="${XDG_DATA_HOME}/asdf"
+export ASDF_CONFIG_FILE="${XDG_CONFIG_HOME}/asdfrc"
 
 export LANG=ja_JP.UTF-8
 export LC_ALL=$LANG
@@ -12,7 +17,6 @@ export HISTFILE=$HOME/.zsh_history
 export HISTSIZE=1000
 export SAVEHIST=500000
 
-export PATH=$HOME/.anyenv/bin:$PATH
 export PATH=$HOME/.local/bin:$PATH
 
 include $HOME/.local.zshenv

--- a/ansible-playbook/roles/homebrew/files/Brewfile
+++ b/ansible-playbook/roles/homebrew/files/Brewfile
@@ -1,7 +1,7 @@
 tap "homebrew/bundle"
 tap "homebrew/core"
 brew "ansible"
-brew "anyenv"
+brew "asdf"
 brew "coreutils"
 brew "direnv"
 brew "gh"

--- a/ansible-playbook/roles/homebrew/files/Brewfile
+++ b/ansible-playbook/roles/homebrew/files/Brewfile
@@ -1,6 +1,5 @@
 tap "homebrew/bundle"
 tap "homebrew/core"
-brew "ansible"
 brew "asdf"
 brew "coreutils"
 brew "direnv"


### PR DESCRIPTION
- そろそろツールを変えたい
- asdf だと nvm もサポートするので嬉しい
- `ASDF_CONFIG_FILE` と `ASDF_DATA_DIR` の設定をした
  - https://asdf-vm.com/manage/configuration.html#environment-variables
  - `ASDF_DIR` は homebrew が設定するデフォルトの `/opt/homebrew/opt/asdf/libexec` のまま